### PR TITLE
allow NaN in the reference matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Most recent change on the bottom.
 
-## [Unreleased]
+## [0.2.0] - Unreleased
 
 ### Added
 - Option to mask out values, with correct counting, using NaN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,7 @@ Most recent change on the bottom.
 
 ## [Unreleased]
 
+### Added
+- Option to mask out values, with correct counting, using NaN
+
 ## [0.1.0] - 2021-05-28

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Notable features:
  - Reduction over arbitrary dimensions of each sample
  - "Batched"/"binned" reduction into multiple running tallies using a per-sample bin index. 
   This can be useful, for example, in accumulating statistics over samples by some kind of "type" index or for accumulating statistics per-graph in a `pytorch_geometric`-like [batching scheme](https://pytorch-geometric.readthedocs.io/en/latest/notes/batching.html). (This feature uses and is similar to [`torch_scatter`](https://pytorch-scatter.readthedocs.io/en/latest/functions/scatter.html).)
+ - Option to ignore NaN values with correct sample counting.
 
 **Note:** the implementations currently heavily uses in-place operations for peformance and memory efficiency. This probably doesn't play nice with the autograd engine — this is currently likely the wrong library for accumulating running statistics you want to backward through. (See [TorchMetrics](https://torchmetrics.readthedocs.io/en/latest/) for a possible alternative.)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="torch_runstats",
-    version="0.1.0",
+    version="0.2.0",
     url="https://github.com/mir-group/pytorch_runstats",
     description="Running/online statistics for PyTorch ",
     long_description=long_description,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -50,7 +50,7 @@ class StatsTruth(RunningStats):
         if not hasattr(self, "_state"):
             return torch.zeros(self._dim)
         average, _, _ = self.batch_result(self._state, self._acc)
-        
+
         if len(average) < self._n_bins:
             N_to_add = self._n_bins - len(average)
             average = torch.cat((average, torch.zeros((N_to_add,)+average.shape[1:])))
@@ -78,8 +78,8 @@ class StatsTruth(RunningStats):
 def test_runstats(dim, reduce_dims, nan_attrs, reduction, do_accumulate_by, allclose):
 
     n_batchs = (random.randint(1, 4), random.randint(1, 4))
-    truth_obj = StatsTruth(dim=dim, reduction=reduction, reduce_dims=reduce_dims)
-    runstats = RunningStats(dim=dim, reduction=reduction, reduce_dims=reduce_dims)
+    truth_obj = StatsTruth(dim=dim, reduction=reduction, reduce_dims=reduce_dims, has_nan=nan_attrs)
+    runstats = RunningStats(dim=dim, reduction=reduction, reduce_dims=reduce_dims, has_nan=nan_attrs)
 
     for n_batch in n_batchs:
         for _ in range(n_batch):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -97,11 +97,13 @@ def test_runstats(dim, reduce_dims, nan_attrs, reduction, do_accumulate_by, allc
             res = runstats.accumulate_batch(batch, accumulate_by=accumulate_by)
             assert allclose(truth, res)
         truth = truth_obj.current_result()
+        # double retrieval to check whether the sqrt was applied twice
+        res = runstats.current_result()
         res = runstats.current_result()
         assert allclose(truth, res)
         truth_obj.reset(reset_n_bins=True)
         runstats.reset(reset_n_bins=True)
-        
+
 @pytest.mark.parametrize("do_accumulate_by", [True, False])
 @pytest.mark.parametrize("nan_attrs", [True, False])
 def test_batching(do_accumulate_by, nan_attrs, allclose):
@@ -143,6 +145,7 @@ def test_batching(do_accumulate_by, nan_attrs, allclose):
             acc = None if accumulate_by is None else accumulate_by[loid:hiid]
             runstats.accumulate_batch(batch, accumulate_by=acc)
 
+        res = runstats.current_result()
         res = runstats.current_result()
         assert allclose(truth, res)
         print("T", truth)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -59,21 +59,22 @@ class StatsTruth(RunningStats):
 
 
 @pytest.mark.parametrize(
-    "dim,reduce_dims,nan_attrs",
+    "dim,reduce_dims",
     [
-        (1, tuple(), False),
-        (1, (0,), True),
-        (3, tuple(), False),
-        (3, (0,), True),
-        ((2, 3), tuple(), False),
-        (torch.Size((1, 2, 1)), tuple(), False),
-        (torch.Size((1, 2, 1)), (1,), False),
-        (torch.Size((3, 2, 4)), (0, 2), False),
-        (torch.Size((3, 2, 4)), (0, 1, 2), True),
+        (1, tuple()),
+        (1, (0,)),
+        (3, tuple()),
+        (3, (0,)),
+        ((2, 3), tuple()),
+        (torch.Size((1, 2, 1)), tuple()),
+        (torch.Size((1, 2, 1)), (1,)),
+        (torch.Size((3, 2, 4)), (0, 2)),
+        (torch.Size((3, 2, 4)), (0, 1, 2)),
     ],
 )
 @pytest.mark.parametrize("reduction", [Reduction.MEAN, Reduction.RMS])
 @pytest.mark.parametrize("do_accumulate_by", [True, False])
+@pytest.mark.parametrize("nan_attrs", [True, False])
 def test_runstats(dim, reduce_dims, nan_attrs, reduction, do_accumulate_by, allclose):
 
     n_batchs = (random.randint(1, 4), random.randint(1, 4))
@@ -83,9 +84,8 @@ def test_runstats(dim, reduce_dims, nan_attrs, reduction, do_accumulate_by, allc
     for n_batch in n_batchs:
         for _ in range(n_batch):
             batch = torch.randn((random.randint(1, 10),) + runstats.dim)
-            if nan_attrs:
+            if nan_attrs and random.choice([True, False]):
                 batch.view(-1)[0] = float("NaN")
-
             if do_accumulate_by and random.choice((True, False)):
                 accumulate_by = torch.randint(
                     0, random.randint(1, 5), size=(batch.shape[0],)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -145,6 +145,8 @@ def test_batching(do_accumulate_by, nan_attrs, allclose):
 
         res = runstats.current_result()
         assert allclose(truth, res)
+        print("T", truth)
+        print("R", res)
         runstats.reset(reset_n_bins=True)
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -163,6 +163,22 @@ def test_zeros(reduction, allclose):
     assert allclose(runstats.current_result(), torch.zeros(dim))
 
 
+@pytest.mark.parametrize("reduction", [Reduction.MEAN, Reduction.RMS])
+@pytest.mark.parametrize("dim", [tuple(), (2,), (1, 3, 2, 7, 2)])
+def test_simple(reduction, allclose, dim):
+    runstats = RunningStats(dim=dim, reduction=reduction)
+    x = torch.randn((113,) + dim)
+    if reduction == Reduction.MEAN:
+        truth = x.mean(dim=0)
+    elif reduction == Reduction.RMS:
+        truth = x.square().mean(dim=0).sqrt()
+    else:
+        raise NotImplementedError
+    res = runstats.accumulate_batch(x)
+    assert res.shape == (1,) + dim  # one bin
+    assert allclose(truth, res)
+
+
 def test_raises():
     runstats = RunningStats(dim=4, reduction=Reduction.MEAN)
     with pytest.raises(ValueError):

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -151,9 +151,6 @@ class RunningStats:
 
                 N = (not_nan).sum(dim=(0,) + reduce_dims)
                 new_sum = new_sum.sum(dim=0)
-                if isinstance(N, numbers.Integral):
-                    N = torch.as_tensor([N], dtype=torch.long)
-                    new_sum = torch.as_tensor([new_sum])
                 new_sum = new_sum.reshape((1,)+new_sum.shape)
                 N = N.reshape((1,)+N.shape)
 

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -186,6 +186,7 @@ class RunningStats:
 
             if has_nan:
 
+
                 # get count
                 N = scatter(not_nan, accumulate_by, dim=0)
                 if len(self._reduce_dims) > 0:
@@ -254,6 +255,7 @@ class RunningStats:
             )
             N = torch.cat((N, N.new_zeros((-N_to_add,) + N.shape[1:])), dim=0)
 
+
         self._state += (new_sum - N * self._state) / (self._n + N)
         self._n += N
 
@@ -298,7 +300,7 @@ class RunningStats:
         if self._reduction == Reduction.MEAN:
             return self._state.clone()
         elif self._reduction == Reduction.RMS:
-            return self._state.sqrt_()
+            return self._state.sqrt()
 
     @property
     def n(self) -> torch.Tensor:

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -208,7 +208,7 @@ class RunningStats:
             average = torch.nan_to_num(new_sum / N, nan=0.0)
 
             if self._reduction == Reduction.RMS:
-                average = average.sqrt_()
+                average.sqrt_()
 
             return average, new_sum, N
 

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -150,13 +150,12 @@ class RunningStats:
             device = new_sum.device
             if has_nan:
 
-                N = (not_nan).sum(dim=(0,) + reduce_dims)
-                new_sum = new_sum.sum(dim=0)
-                # if isinstance(N, numbers.Integral):
-                #     N = torch.as_tensor([N], dtype=torch.long, device=device)
-                #     new_sum = torch.as_tensor([new_sum], device=device)
-                new_sum = new_sum.reshape((1,)+new_sum.shape)
-                N = N.reshape((1,)+N.shape)
+                if len(self._reduce_dims) > 0:
+                    N = (not_nan).sum(reduce_dims)
+                else:
+                    N = not_nan
+                new_sum = new_sum.sum(dim=0, keepdim=True)
+                N = N.sum(dim=0, keepdim=True)
 
             else:
 

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -201,10 +201,8 @@ class RunningStats:
 
                 N = torch.bincount(accumulate_by).reshape((-1,)+(1,)*(len(new_sum.shape)-1))
 
-                # Reduce along non-batch dimensions
-                if len(self._reduce_dims) > 0:
-                    # Each sample is now a reduction over _reduction_factor samples
-                    N *= self._reduction_factor
+                # Each sample is now a reduction over _reduction_factor samples
+                N *= self._reduction_factor
 
             average = torch.nan_to_num(new_sum / N, nan=0.0)
 

--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -265,7 +265,8 @@ class RunningStats:
                 dim=0,
             )
             self._n = torch.cat((self._n, self._n.new_zeros((N_to_add, )+self._n.shape[1:])), dim=0)
-            assert self._state.shape == (self._n_bins + N_to_add,) + self._dim
+
+            # assert self._state.shape == (self._n_bins + N_to_add,) + self._dim
             self._n_bins += N_to_add
 
         elif N_to_add < 0:
@@ -274,11 +275,6 @@ class RunningStats:
                 (new_sum, new_sum.new_zeros((-N_to_add,) + new_sum.shape[1:])), dim=0
             )
             N = torch.cat((N, N.new_zeros((-N_to_add,) + N.shape[1:])), dim=0)
-
-        ndim = len(self._state.shape)-len(N.shape)
-        N = N.reshape(N.shape+(1,)*ndim)
-        ndim = len(self._state.shape)-len(new_sum.shape)
-        new_sum = new_sum.reshape(new_sum.shape+(1,)*ndim)
 
         self._state += (new_sum - N * self._state) / (self._n + N)
         self._n += N


### PR DESCRIPTION
New Feature: allow NaN exists in the reference matrix.

It can exclude NaN entries when computing mean values. It works for both plain mode and the mode using `accumulate_by` matrix. But for the later case, it only works when a full reduction is apply. 