### PR TITLE
set device in _runstats accumulate state

### DIFF
--- a/torch_runstats/_runstats.py
+++ b/torch_runstats/_runstats.py
@@ -327,8 +327,10 @@ class RunningStats:
             # need to expand the parameter state
             n = _pad_dim0(n, -N_to_add)
             state = _pad_dim0(state, -N_to_add)
-        self._state += n * (state - self._state) / (self._n + n)
-        self._n += n
+
+        device = self._state.device
+        self._state += n.to(device) * (state.to(device) - self._state) / (self._n + n.to(device))
+        self._n += n.to(device)
         # Make div by zero 0
         self._state = torch.nan_to_num_(self._state, nan=0.0)
 


### PR DESCRIPTION
Reads the device of self._state and changes the device of n and state respectively.
With this change the ddp test passed on a single node multi gpu system both with 2 and 3 visible gpus.